### PR TITLE
Fix/change? behavior with eye position offset when looking at nearby blocks when using PRO setting

### DIFF
--- a/FOXCamera/FOXCamera.lua
+++ b/FOXCamera/FOXCamera.lua
@@ -522,8 +522,11 @@ local function cameraRender(delta)
     if isHost and curr.doEyeRotation then
       local targeted = targetcast(cameraPos + playerPos, cameraDir)
       if targeted then
-        local lookOffset = player:getLookDir() * (player:getVelocity():length() * 1.1)
-        eyeOffset = targeted:sub(playerPos):sub(eyeHeight):sub(lookOffset)
+        local scalar = player:getVelocity():length() * 1.1
+        local lookOffset = player:getLookDir() * scalar
+        if (scalar ~= 0) then
+          eyeOffset = targeted:sub(playerPos):sub(eyeHeight):sub(lookOffset)
+        end
       end
     end
   end


### PR DESCRIPTION
I was standing around trying to open a trapdoor and could not target it all when I was about 1-3 blocks away from it.

This PR fixes this issue for my specific scenario and I don't expect it to be merged with how vague this is but I figure maybe somebody someday will be staring at a trapdoor trying to open/close it and wonder where the issue is.

I have no clue why it works but I reasoned my way to this solution by looking at `targetcast`, then `targeted`, and just tried with and without updating `eyeOffset`, so I'm sorry I can't offer a reason or meaningful insight for why I think this is a good idea other than "it feels better on my end".

Attached is an image of roughly the setup when I ran into this again when testing the "PRO" setting once more.
<img width="1920" height="981" alt="image" src="https://github.com/user-attachments/assets/1cb5dcc9-9aab-4d24-ad05-fa95b7bfea44" />


Thank you for this really cool library, by the way, hope this is no trouble.