### PR TITLE
Add applyFilterAsync

### DIFF
--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -246,6 +246,8 @@ end
 ---Another filter can be used as a mask.
 ---
 ---https://github.com/Bitslayn/FOX-s-Figura-APIs/wiki/FOXFiltersAPI#getting-started
+---@param name string
+---@param self Texture
 ---@param x integer
 ---@param y integer
 ---@param w integer
@@ -253,15 +255,13 @@ end
 ---@param flt FOXFilter
 ---@param msk FOXFilter?
 ---@param callback fun(result: Texture)?
----@param name string?
 ---@return nil
-function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
+local function applyFilterAsyncNamed(name, self, x, y, w, h, flt, msk, callback)
 	-- Check if Task is available
 	local success, Task = pcall(require, "./task")
 	assert(success, "You must add task.lua to your avatar to use this function.")
 
 	callback = callback or function() end
-	name = name or self:getName()
 
 	-- Sanitize filters being applied
 
@@ -279,8 +279,8 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 		-- Apply filter + mask
 
 		local byt = self:save()
-		textures:read("_flt", byt):applyFilterAsync(x, y, w, h, flt, nil, function(_flt)
-			textures:read("_msk", byt):applyFilterAsync(x, y, w, h, msk, nil, function(_msk)
+		applyFilterAsyncNamed(name, textures:read("_flt", byt), x, y, w, h, flt, nil, function(_flt)
+			applyFilterAsyncNamed(name, textures:read("_msk", byt), x, y, w, h, msk, nil, function(_msk)
 				---@diagnostic disable-next-line: undefined-field
 				if _flt.invert then -- Figura 0.1.6+
 					---@diagnostic disable-next-line: undefined-field
@@ -308,8 +308,8 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 						callback(self)
 					end)
 				end
-			end, name)
-		end, name)
+			end)
+		end)
 	else
 		-- Apply filter
 		Task(1,#flt[1].mod,function(i)
@@ -371,6 +371,25 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 			callback(self)
 		end)
 	end
+end
+
+---Applies a texture filter to an area of pixels asynchronously, keeping instruction limits in mind. The filter can be created by calling `<FOXFilterAPI>.newFilter()` after requiring FOXFilters.
+---
+---It is recommended to call `<Texture>:update()` after doing anything with textures. For asynchronous application, do this inside the callback function.
+---
+---Another filter can be used as a mask.
+---
+---https://github.com/Bitslayn/FOX-s-Figura-APIs/wiki/FOXFiltersAPI#getting-started
+---@param x integer
+---@param y integer
+---@param w integer
+---@param h integer
+---@param flt FOXFilter
+---@param msk FOXFilter?
+---@param callback fun(result: Texture)?
+---@return nil
+function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
+	applyFilterAsyncNamed(self:getName(), self, x, y, w, h, flt, msk, callback)
 end
 
 --#ENDREGION --=================================================================================================================

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -239,6 +239,136 @@ function texture:applyFilter(x, y, w, h, flt, msk)
 	return self
 end
 
+---Applies a texture filter to an area of pixels asynchronously, keeping instruction limits in mind. The filter can be created by calling `<FOXFilterAPI>.newFilter()` after requiring FOXFilters.
+---
+---It is recommended to call `<Texture>:update()` after doing anything with textures.
+---
+---Another filter can be used as a mask.
+---
+---https://github.com/Bitslayn/FOX-s-Figura-APIs/wiki/FOXFiltersAPI#getting-started
+---@param x integer
+---@param y integer
+---@param w integer
+---@param h integer
+---@param flt FOXFilter
+---@param msk FOXFilter?
+---@param callback fun(result: Texture)
+---@return nil
+function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
+	-- Check if Task is available
+	local success, Task = pcall(require, "./task")
+	assert(success, "You must add task.lua to your avatar to use this function.")
+
+	-- Sanitize filters being applied
+
+	if flt and flt[1] then
+		flt = cache[flt[1].hsh] or copy(flt)
+		cache[flt[1].hsh] = flt
+	end
+
+	if msk and msk[1] then
+		msk = cache[msk[1].hsh] or copy(msk)
+		cache[msk[1].hsh] = msk
+	end
+
+	if msk and msk[1].mod[1] and flt and flt[1].mod[1] then
+		-- Apply filter + mask
+
+		local byt = self:save()
+		textures:read("_flt", byt):applyFilterAsync(x, y, w, h, flt, nil, function(_flt)
+			textures:read("_msk", byt):applyFilterAsync(x, y, w, h, msk, nil, function(_msk)
+				---@diagnostic disable-next-line: undefined-field
+				if _flt.invert then -- Figura 0.1.6+
+					---@diagnostic disable-next-line: undefined-field
+					_flt:multiply(_msk, x, y, w, h)
+					---@diagnostic disable-next-line: undefined-field
+					_msk:invert(x, y, w, h)
+
+					---@diagnostic disable-next-line: undefined-field
+					self:multiply(_msk, x, y, w, h)
+						:add(_flt, x, y, w, h)
+					callback(self)
+				else -- Figura <0.1.6
+					local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+					Task(x,x+w-1,function(_x)
+						progress()
+						Task(y,y+h-1,function(_y)
+							self:setPixel(_x,_y,math.lerp(
+								self:getPixel(_x, _y),
+								_flt:getPixel(_x, _y),
+								_msk:getPixel(_x, _y)
+							))
+						end)
+					end,
+					function()
+						callback(self)
+					end)
+				end
+			end)
+		end)
+	else
+		-- Apply filter
+		Task(1,#flt[1].mod,function(i)
+			local mod = flt[1].mod[i]
+			local val = mod.val
+
+			if mod.typ == "mat" then
+				self:applyMatrix(x, y, w, h, val --[[@as Matrix4]], true) -- Clip here for 1.21+
+			elseif mod.typ == "fun" then
+				local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+				Task(x,x+w-1,function(_x)
+					progress()
+					Task(y,y+h-1,function(_y)
+						self:applyFunc(_x, _y, 1, 1, val --[[@as FOXFilter.Function]])
+					end)
+				end)
+			elseif mod.typ == "ker" then
+				local _tmp = textures:read("_tmp", self:save())
+
+				-- Apply kernel to texture
+
+				local r_len = #val --[[@as number[][] ]]
+				local c_len = #val --[[@as number[][] ]][1]
+				local r_off = math.ceil(r_len / 2)
+				local c_off = math.ceil(c_len / 2)
+				local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+				Task(x,x+w-1,function(u)
+					progress()
+					Task(y,y+h-1,function(v)
+						local col = self:getPixel(u,v)
+						local sum = vec(0, 0, 0)
+
+						-- Apply kernel to pixel
+
+						local x_max = math.max(0, u - c_off + 1)
+						local y_max = math.max(0, v - r_off + 1)
+						local x_min = math.min(w, u + c_len - c_off + 1)
+						local y_min = math.min(h, v + r_len - r_off + 1)
+								
+						Task(x_max,x_min-1,function(_u)
+							Task(y_max,y_min-1,function(_v)
+								local _col = _tmp:getPixel(_u,_v)
+								local c = _u - u + c_off
+								local r = _v - v + r_off
+
+								sum = val --[[@as number[][] ]][r][c] * _col.xyz + sum
+							end)
+						end,
+						function()
+							self:setPixel(u,v,sum:augmented(col.w):applyFunc(function(vtx)
+								return math.clamp(vtx, 0, 1) -- Clip here for 1.21+
+							end))
+						end)
+					end)
+				end)
+			end
+		end,
+		function()
+			callback(self)
+		end)
+	end
+end
+
 --#ENDREGION --=================================================================================================================
 --#REGION ˚♡ Modifiers ♡˚
 --==============================================================================================================================

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -241,7 +241,7 @@ end
 
 ---Applies a texture filter to an area of pixels asynchronously, keeping instruction limits in mind. The filter can be created by calling `<FOXFilterAPI>.newFilter()` after requiring FOXFilters.
 ---
----It is recommended to call `<Texture>:update()` after doing anything with textures.
+---It is recommended to call `<Texture>:update()` after doing anything with textures. For asynchronous application, do this inside the callback function.
 ---
 ---Another filter can be used as a mask.
 ---

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -3,7 +3,7 @@ ____  ___ __   __
 | __|/ _ \\ \ / /
 | _|| (_) |> w <
 |_|  \___//_/ \_\
-FOX's Filters API v1.3d
+FOX's Filters API v1.4
 
 Github: https://github.com/Bitslayn/FOX-s-Figura-APIs/blob/main/Utilities/Filters.lua
 Wiki: https://github.com/Bitslayn/FOX-s-Figura-APIs/wiki/FOXFiltersAPI

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -259,6 +259,8 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 	local success, Task = pcall(require, "./task")
 	assert(success, "You must add task.lua to your avatar to use this function.")
 
+	callback = callback or function() end
+
 	-- Sanitize filters being applied
 
 	if flt and flt[1] then

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -247,6 +247,7 @@ end
 ---
 ---https://github.com/Bitslayn/FOX-s-Figura-APIs/wiki/FOXFiltersAPI#getting-started
 ---@param name string
+---@param len integer
 ---@param self Texture
 ---@param x integer
 ---@param y integer
@@ -256,7 +257,7 @@ end
 ---@param msk FOXFilter?
 ---@param callback fun(result: Texture)?
 ---@return nil
-local function applyFilterAsyncNamed(name, self, x, y, w, h, flt, msk, callback)
+local function applyFilterAsyncNamed(name, len, self, x, y, w, h, flt, msk, callback)
 	-- Check if Task is available
 	local success, Task = pcall(require, "./task")
 	assert(success, "You must add task.lua to your avatar to use this function.")
@@ -278,9 +279,11 @@ local function applyFilterAsyncNamed(name, self, x, y, w, h, flt, msk, callback)
 	if msk and msk[1].mod[1] and flt and flt[1].mod[1] then
 		-- Apply filter + mask
 
+		len = len + 1
+
 		local byt = self:save()
-		applyFilterAsyncNamed(name, textures:read("_flt", byt), x, y, w, h, flt, nil, function(_flt)
-			applyFilterAsyncNamed(name, textures:read("_msk", byt), x, y, w, h, msk, nil, function(_msk)
+		applyFilterAsyncNamed(name, len, textures:read("_flt", byt), x, y, w, h, flt, nil, function(_flt)
+			applyFilterAsyncNamed(name, len, textures:read("_msk", byt), x, y, w, h, msk, nil, function(_msk)
 				---@diagnostic disable-next-line: undefined-field
 				if _flt.invert then -- Figura 0.1.6+
 					---@diagnostic disable-next-line: undefined-field
@@ -293,83 +296,84 @@ local function applyFilterAsyncNamed(name, self, x, y, w, h, flt, msk, callback)
 						:add(_flt, x, y, w, h)
 					callback(self)
 				else -- Figura <0.1.6
-					local progress = Task.ProgressBar("Applying filter to "..name.." > Mask",w)
-					Task(x,x+w-1,function(_x)
-						progress()
-						Task(y,y+h-1,function(_y)
-							self:setPixel(_x,_y,math.lerp(
-								self:getPixel(_x, _y),
-								_flt:getPixel(_x, _y),
-								_msk:getPixel(_x, _y)
-							))
+					local progress = Task.ProgressBar("Applying filter to " .. name .. " (" .. len .. "/" .. len .. ")", w)
+					Task(x, x + w - 1, function(_x)
+							progress()
+							Task(y, y + h - 1, function(_y)
+								self:setPixel(_x, _y, math.lerp(
+									self:getPixel(_x, _y),
+									_flt:getPixel(_x, _y),
+									_msk:getPixel(_x, _y)
+								))
+							end)
+						end,
+						function()
+							callback(self)
 						end)
-					end,
-					function()
-						callback(self)
-					end)
 				end
 			end)
 		end)
 	else
 		-- Apply filter
-		Task(1,#flt[1].mod,function(i)
-			local mod = flt[1].mod[i]
-			local val = mod.val
+		Task(1, #flt[1].mod, function(i)
+				local mod = flt[1].mod[i]
+				local val = mod.val
 
-			if mod.typ == "mat" then
-				self:applyMatrix(x, y, w, h, val --[[@as Matrix4]], true) -- Clip here for 1.21+
-			elseif mod.typ == "fun" then
-				local progress = Task.ProgressBar("Applying filter to "..name.." > Filter",w)
-				Task(x,x+w-1,function(_x)
-					progress()
-					Task(y,y+h-1,function(_y)
-						self:applyFunc(_x, _y, 1, 1, val --[[@as FOXFilter.Function]])
-					end)
-				end)
-			elseif mod.typ == "ker" then
-				local _tmp = textures:read("_tmp", self:save())
-
-				-- Apply kernel to texture
-
-				local r_len = #val --[[@as number[][] ]]
-				local c_len = #val --[[@as number[][] ]][1]
-				local r_off = math.ceil(r_len / 2)
-				local c_off = math.ceil(c_len / 2)
-				local progress = Task.ProgressBar("Applying filter to "..name.." > Filter",w)
-				Task(x,x+w-1,function(u)
-					progress()
-					Task(y,y+h-1,function(v)
-						local col = self:getPixel(u,v)
-						local sum = vec(0, 0, 0)
-
-						-- Apply kernel to pixel
-
-						local x_max = math.max(0, u - c_off + 1)
-						local y_max = math.max(0, v - r_off + 1)
-						local x_min = math.min(w, u + c_len - c_off + 1)
-						local y_min = math.min(h, v + r_len - r_off + 1)
-								
-						Task(x_max,x_min-1,function(_u)
-							Task(y_max,y_min-1,function(_v)
-								local _col = _tmp:getPixel(_u,_v)
-								local c = _u - u + c_off
-								local r = _v - v + r_off
-
-								sum = val --[[@as number[][] ]][r][c] * _col.xyz + sum
-							end)
-						end,
-						function()
-							self:setPixel(u,v,sum:augmented(col.w):applyFunc(function(vtx)
-								return math.clamp(vtx, 0, 1) -- Clip here for 1.21+
-							end))
+				if mod.typ == "mat" then
+					self:applyMatrix(x, y, w, h, val --[[@as Matrix4]], true) -- Clip here for 1.21+
+				elseif mod.typ == "fun" then
+					local progress = Task.ProgressBar("Applying filter to " .. name .. " (" .. i .. "/" .. len .. ")", w)
+					Task(x, x + w - 1, function(_x)
+						progress()
+						Task(y, y + h - 1, function(_y)
+							self:applyFunc(_x, _y, 1, 1, val --[[@as FOXFilter.Function]])
 						end)
 					end)
-				end)
-			end
-		end,
-		function()
-			callback(self)
-		end)
+				elseif mod.typ == "ker" then
+					local _tmp = textures:read("_tmp", self:save())
+
+					-- Apply kernel to texture
+
+					local r_len = #val --[[@as number[][] ]]
+					local c_len = #val --[[@as number[][] ]][1]
+					local r_off = math.ceil(r_len / 2)
+					local c_off = math.ceil(c_len / 2)
+					local progress = Task.ProgressBar("Applying filter to " .. name .. " (" .. i .. "/" .. len .. ")", w)
+					Task(x, x + w - 1, function(u)
+						progress()
+						Task(y, y + h - 1, function(v)
+							local col = self:getPixel(u, v)
+							local sum = vec(0, 0, 0)
+
+							-- Apply kernel to pixel
+
+							local x_max = math.max(0, u - c_off + 1)
+							local y_max = math.max(0, v - r_off + 1)
+							local x_min = math.min(w, u + c_len - c_off + 1)
+							local y_min = math.min(h, v + r_len - r_off + 1)
+
+							Task(x_max, x_min - 1, function(_u)
+									Task(y_max, y_min - 1, function(_v)
+										local _col = _tmp:getPixel(_u, _v)
+										local c = _u - u + c_off
+										local r = _v - v + r_off
+
+										sum = val --[[@as number[][] ]][r][c] * _col.xyz + sum
+									end)
+								end,
+								function()
+									self:setPixel(u, v, sum:augmented(col.w):applyFunc(function(vtx)
+										return math.clamp(vtx, 0, 1) -- Clip here for 1.21+
+									end))
+								end)
+						end)
+					end)
+				end
+			end,
+			function()
+				Task.ProgressBar("Applying filter to " .. name .. " (" .. len .. "/" .. len .. ")", 1)()
+				callback(self)
+			end)
 	end
 end
 
@@ -389,7 +393,7 @@ end
 ---@param callback fun(result: Texture)?
 ---@return nil
 function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
-	applyFilterAsyncNamed(self:getName(), self, x, y, w, h, flt, msk, callback)
+	applyFilterAsyncNamed(self:getName(), #flt[1].mod, self, x, y, w, h, flt, msk, callback)
 end
 
 --#ENDREGION --=================================================================================================================

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -253,13 +253,15 @@ end
 ---@param flt FOXFilter
 ---@param msk FOXFilter?
 ---@param callback fun(result: Texture)?
+---@param name string?
 ---@return nil
-function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
+function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 	-- Check if Task is available
 	local success, Task = pcall(require, "./task")
 	assert(success, "You must add task.lua to your avatar to use this function.")
 
 	callback = callback or function() end
+	name = name or self:getName()
 
 	-- Sanitize filters being applied
 
@@ -291,7 +293,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 						:add(_flt, x, y, w, h)
 					callback(self)
 				else -- Figura <0.1.6
-					local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+					local progress = Task.ProgressBar("Applying filter to "..name,w)
 					Task(x,x+w-1,function(_x)
 						progress()
 						Task(y,y+h-1,function(_y)
@@ -306,8 +308,8 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 						callback(self)
 					end)
 				end
-			end)
-		end)
+			end, name)
+		end, name)
 	else
 		-- Apply filter
 		Task(1,#flt[1].mod,function(i)
@@ -317,7 +319,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 			if mod.typ == "mat" then
 				self:applyMatrix(x, y, w, h, val --[[@as Matrix4]], true) -- Clip here for 1.21+
 			elseif mod.typ == "fun" then
-				local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+				local progress = Task.ProgressBar("Applying filter to "..name,w)
 				Task(x,x+w-1,function(_x)
 					progress()
 					Task(y,y+h-1,function(_y)
@@ -333,7 +335,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 				local c_len = #val --[[@as number[][] ]][1]
 				local r_off = math.ceil(r_len / 2)
 				local c_off = math.ceil(c_len / 2)
-				local progress = Task.ProgressBar("Applying filter to "..self:getName(),w)
+				local progress = Task.ProgressBar("Applying filter to "..name,w)
 				Task(x,x+w-1,function(u)
 					progress()
 					Task(y,y+h-1,function(v)
@@ -839,7 +841,7 @@ end
 --#REGION ˚♡ API ♡˚
 --==============================================================================================================================
 
----Creates a new texture filter which can be applied by calling `<Texture>:applyFilter()`.
+---Creates a new texture filter which can be applied by calling `<Texture>:applyFilter()` or `<Texture>:applyFilterAsync()`.
 ---
 ---Filter modifiers can be chained together to create complex filters, and are applied in order.
 ---

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -293,7 +293,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 						:add(_flt, x, y, w, h)
 					callback(self)
 				else -- Figura <0.1.6
-					local progress = Task.ProgressBar("Applying filter to "..name,w)
+					local progress = Task.ProgressBar("Applying filter to "..name.." > Mask",w)
 					Task(x,x+w-1,function(_x)
 						progress()
 						Task(y,y+h-1,function(_y)
@@ -319,7 +319,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 			if mod.typ == "mat" then
 				self:applyMatrix(x, y, w, h, val --[[@as Matrix4]], true) -- Clip here for 1.21+
 			elseif mod.typ == "fun" then
-				local progress = Task.ProgressBar("Applying filter to "..name,w)
+				local progress = Task.ProgressBar("Applying filter to "..name.." > Filter",w)
 				Task(x,x+w-1,function(_x)
 					progress()
 					Task(y,y+h-1,function(_y)
@@ -335,7 +335,7 @@ function texture:applyFilterAsync(x, y, w, h, flt, msk, callback, name)
 				local c_len = #val --[[@as number[][] ]][1]
 				local r_off = math.ceil(r_len / 2)
 				local c_off = math.ceil(c_len / 2)
-				local progress = Task.ProgressBar("Applying filter to "..name,w)
+				local progress = Task.ProgressBar("Applying filter to "..name.." > Filter",w)
 				Task(x,x+w-1,function(u)
 					progress()
 					Task(y,y+h-1,function(v)

--- a/Utilities/Filters.lua
+++ b/Utilities/Filters.lua
@@ -252,7 +252,7 @@ end
 ---@param h integer
 ---@param flt FOXFilter
 ---@param msk FOXFilter?
----@param callback fun(result: Texture)
+---@param callback fun(result: Texture)?
 ---@return nil
 function texture:applyFilterAsync(x, y, w, h, flt, msk, callback)
 	-- Check if Task is available


### PR DESCRIPTION
Adds an async version of applyFilter using [Task](https://github.com/Manuel-3/figura-scripts/tree/main/src/task) as a dependency.
This allows filters to be used on the default permission level by spreading the calculations over several frames/ticks.

Usage example:
```lua
local filters = require("Filters")

local filter = filters.newFilter()
    :grayscale()
    :limit(4)
    :gradient(
        vectors.hexToRGB("#294139"),
        vectors.hexToRGB("#39594a"),
        vectors.hexToRGB("#5a7942"),
        vectors.hexToRGB("#7b8210")
    )

local tex = textures["steve"]
tex:applyFilterAsync(0, 0, tex:getDimensions().x, tex:getDimensions().y, filter, nil, function(result)
  result:update()
end)
```